### PR TITLE
Search for subnets by location when role has taxonomies test

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -56,7 +56,8 @@ module Api
 
     # overwrites resource_scope in FindCommon to consider nested objects
     def resource_scope(options = {})
-      resource_class.where(:id => (super(options).ids & parent_scope.ids).uniq)
+      child_scope = super(options)
+      child_scope.merge(parent_scope).readonly(false)
     end
 
     def parent_scope

--- a/test/controllers/api/v2/subnets_controller_test.rb
+++ b/test/controllers/api/v2/subnets_controller_test.rb
@@ -218,4 +218,19 @@ class Api::V2::SubnetsControllerTest < ActionController::TestCase
 
     assert_response :success
   end
+
+  test "should return subnets when searching by location as non-admin user and role has taxonomies" do
+    org = FactoryBot.create(:organization)
+    loc = FactoryBot.create(:location)
+    FactoryBot.create(:subnet_ipv4, :organizations => [org], :locations => [loc])
+    manager = roles(:manager)
+    role = manager.clone :name => "Clonned manager", :organizations => [org], :locations => [loc]
+    role.save!
+    user = FactoryBot.create(:user, :organizations => [org], :locations => [loc], :default_organization_id => org.id,
+                             :default_location_id => loc.id, :roles => [role])
+    as_user user do
+      get :index, params: { :location_id => loc.id }
+    end
+    assert_response :success
+  end
 end


### PR DESCRIPTION
The only difference from the test directly above it is that the role has taxonomies assigned.